### PR TITLE
Include on_shutdown decorator in djhuey

### DIFF
--- a/huey/contrib/djhuey/__init__.py
+++ b/huey/contrib/djhuey/__init__.py
@@ -118,6 +118,7 @@ scheduled = HUEY.scheduled
 
 # Hooks.
 on_startup = HUEY.on_startup
+on_shutdown = HUEY.on_shutdown
 pre_execute = HUEY.pre_execute
 post_execute = HUEY.post_execute
 signal = HUEY.signal


### PR DESCRIPTION
The new `on_shutdown` decorator was missing from the djhuey addon.